### PR TITLE
Rewrite the update script in PHP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+.idea
+

--- a/.phpunit.xml
+++ b/.phpunit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<phpunit bootstrap="./vendor/autoload.php">
+    <testsuites>
+        <testsuite name="All tests suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+
+</phpunit>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+dist: trusty
+language: php
+php:
+  - '5.6'
+  - '7.0'
+  - hhvm # on Trusty only
+  - nightly
+
+install:
+    # flags to pass to install
+    - flags="--ansi --prefer-dist --no-interaction --optimize-autoloader --no-suggest --no-progress"
+    # install dependencies using system provided composer binary
+    - composer install $flags
+
+script:
+    - composer test

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,35 @@
+{
+	"name": "droidwiki/mediawiki-updater",
+	"type": "project",
+	"require": {
+		"cpliakas/git-wrapper": "^1.7",
+		"symfony/config": "^3.3.10",
+		"symfony/dependency-injection": "^3.3.10",
+		"ulrichsg/getopt-php": "^3.0",
+		"geoffroy-aubry/logger": "^1.1",
+		"jakub-onderka/php-parallel-lint": "^0.9.2",
+		"mediawiki/mediawiki-codesniffer": "^13.0"
+	},
+	"autoload": {
+		"psr-4": {
+			"DroidWiki\\": "src/DroidWiki/"
+		}
+	},
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "Florian Schmidt",
+			"email": "florian.schmidt@droidwiki.org"
+		}
+	],
+	"require-dev": {
+		"phpunit/phpunit": "^5.7"
+	},
+	"scripts": {
+		"test": [
+			"parallel-lint . --exclude vendor",
+			"phpcs -p -s",
+			"phpunit -c .phpunit.xml --bootstrap vendor/autoload.php tests/"
+		]
+	}
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,2099 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "b289f4c9d9f113ea76e0dd076ad75b04",
+    "content-hash": "dc54343ad9d6e9b078da19b08bc64f0b",
+    "packages": [
+        {
+            "name": "cpliakas/git-wrapper",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cpliakas/git-wrapper.git",
+                "reference": "1a2f1131ec9ebe04a0b729b141396fa55f992d44"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cpliakas/git-wrapper/zipball/1a2f1131ec9ebe04a0b729b141396fa55f992d44",
+                "reference": "1a2f1131ec9ebe04a0b729b141396fa55f992d44",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "symfony/event-dispatcher": "~2.3|~3.0",
+                "symfony/process": "~2.3|~3.0"
+            },
+            "require-dev": {
+                "pdepend/pdepend": "~1.0",
+                "phploc/phploc": "~2.0",
+                "phpmd/phpmd": "~1.0",
+                "phpunit/phpunit": "~3.0",
+                "psr/log": "~1.0",
+                "scrutinizer/ocular": "~1.0",
+                "sebastian/phpcpd": "~2.0",
+                "symfony/filesystem": "~2.0"
+            },
+            "suggest": {
+                "monolog/monolog": "Enables logging of executed git commands"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "GitWrapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Pliakas",
+                    "email": "opensource@chrispliakas.com"
+                }
+            ],
+            "description": "A PHP wrapper around the Git command line utility.",
+            "homepage": "https://github.com/cpliakas/git-wrapper",
+            "keywords": [
+                "git"
+            ],
+            "time": "2016-04-19 16:12:33"
+        },
+        {
+            "name": "geoffroy-aubry/helpers",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/geoffroy-aubry/Helpers.git",
+                "reference": "09e787e554158d7c2233a27107d2949824cd5602"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/geoffroy-aubry/Helpers/zipball/09e787e554158d7c2233a27107d2949824cd5602",
+                "reference": "09e787e554158d7c2233a27107d2949824cd5602",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "skleeschulte/base32": "^0.0.2"
+            },
+            "require-dev": {
+                "apigen/apigen": "2.8.0",
+                "phpmd/phpmd": "2.0.*",
+                "phpunit/phpunit": ">=3.7",
+                "satooshi/php-coveralls": "dev-master",
+                "squizlabs/php_codesniffer": "1.4.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "GAubry\\Helpers": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Geoffroy Aubry",
+                    "email": "geoffroy.aubry@free.fr"
+                }
+            ],
+            "description": "Some helpers used in several personal packages and a Debug class useful for don't forgetting where debug traces are.",
+            "keywords": [
+                "debug",
+                "helpers",
+                "tools"
+            ],
+            "time": "2017-10-07 15:15:01"
+        },
+        {
+            "name": "geoffroy-aubry/logger",
+            "version": "v1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/geoffroy-aubry/Logger.git",
+                "reference": "c4bdba86091ab414f523a1e33a0f85cd1541635a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/geoffroy-aubry/Logger/zipball/c4bdba86091ab414f523a1e33a0f85cd1541635a",
+                "reference": "c4bdba86091ab414f523a1e33a0f85cd1541635a",
+                "shasum": ""
+            },
+            "require": {
+                "geoffroy-aubry/helpers": "1.*",
+                "php": ">=5.3.3",
+                "psr/log": "1.0.0"
+            },
+            "require-dev": {
+                "apigen/apigen": "2.8.0",
+                "phpmd/phpmd": "1.4.*",
+                "phpunit/phpunit": ">=3.7",
+                "satooshi/php-coveralls": "dev-master",
+                "squizlabs/php_codesniffer": "1.4.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "GAubry\\Logger": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Geoffroy Aubry",
+                    "email": "geoffroy.aubry@free.fr"
+                }
+            ],
+            "description": "PSR-3 logger for adding colors and indentation on PHP CLI output.",
+            "keywords": [
+                "bash color logging",
+                "color logging",
+                "indent logging",
+                "logger",
+                "psr-3"
+            ],
+            "time": "2013-07-03 09:20:17"
+        },
+        {
+            "name": "jakub-onderka/php-parallel-lint",
+            "version": "v0.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JakubOnderka/PHP-Parallel-Lint.git",
+                "reference": "2ead2e4043ab125bee9554f356e0a86742c2d4fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JakubOnderka/PHP-Parallel-Lint/zipball/2ead2e4043ab125bee9554f356e0a86742c2d4fa",
+                "reference": "2ead2e4043ab125bee9554f356e0a86742c2d4fa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "jakub-onderka/php-console-highlighter": "~0.3",
+                "nette/tester": "~1.3"
+            },
+            "suggest": {
+                "jakub-onderka/php-console-highlighter": "Highlight syntax in code snippet"
+            },
+            "bin": [
+                "parallel-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "./"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jakub Onderka",
+                    "email": "jakub.onderka@gmail.com"
+                }
+            ],
+            "description": "This tool check syntax of PHP files about 20x faster than serial check.",
+            "homepage": "https://github.com/JakubOnderka/PHP-Parallel-Lint",
+            "time": "2015-12-15 10:42:16"
+        },
+        {
+            "name": "mediawiki/mediawiki-codesniffer",
+            "version": "v13.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wikimedia/mediawiki-tools-codesniffer.git",
+                "reference": "296d53b0a02b41d478b028651bb3ca7ee07c9074"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wikimedia/mediawiki-tools-codesniffer/zipball/296d53b0a02b41d478b028651bb3ca7ee07c9074",
+                "reference": "296d53b0a02b41d478b028651bb3ca7ee07c9074",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 5.5.9",
+                "squizlabs/php_codesniffer": "3.0.2"
+            },
+            "require-dev": {
+                "jakub-onderka/php-console-highlighter": "0.3.2",
+                "jakub-onderka/php-parallel-lint": "0.9.2",
+                "phpunit/phpunit": "~4.1"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "MediaWiki CodeSniffer Standards",
+            "homepage": "https://www.mediawiki.org/wiki/Manual:Coding_conventions/PHP",
+            "keywords": [
+                "codesniffer",
+                "mediawiki"
+            ],
+            "time": "2017-09-24 03:33:15"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14 16:28:37"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Psr\\Log\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2012-12-21 11:40:51"
+        },
+        {
+            "name": "skleeschulte/base32",
+            "version": "0.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/skleeschulte/php-base32.git",
+                "reference": "42b651598d42ca51c00a6e71d2587e64e6e80734"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/skleeschulte/php-base32/zipball/42b651598d42ca51c00a6e71d2587e64e6e80734",
+                "reference": "42b651598d42ca51c00a6e71d2587e64e6e80734",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SKleeschulte\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stefan Kleeschulte",
+                    "email": "stefan.kleeschulte@smk.biz",
+                    "homepage": "http://rays-blog.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Base32 encoding and decoding class (RFC 4648, RFC 4648 extended hex, Crockford, z-base-32/Zooko).",
+            "homepage": "https://github.com/skleeschulte/php-base32",
+            "keywords": [
+                "base32",
+                "bcmath",
+                "bytestring",
+                "crockford",
+                "decode",
+                "encode",
+                "integer",
+                "rfc4686",
+                "z-base-32",
+                "zooko"
+            ],
+            "time": "2015-11-19 14:01:26"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "c7594a88ae75401e8f8d0bd4deb8431b39045c51"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/c7594a88ae75401e8f8d0bd4deb8431b39045c51",
+                "reference": "c7594a88ae75401e8f8d0bd4deb8431b39045c51",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2017-07-18 01:12:32"
+        },
+        {
+            "name": "symfony/config",
+            "version": "v3.3.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "4ab62407bff9cd97c410a7feaef04c375aaa5cfd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/4ab62407bff9cd97c410a7feaef04c375aaa5cfd",
+                "reference": "4ab62407bff9cd97c410a7feaef04c375aaa5cfd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/filesystem": "~2.8|~3.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.3",
+                "symfony/finder": "<3.3"
+            },
+            "require-dev": {
+                "symfony/dependency-injection": "~3.3",
+                "symfony/finder": "~3.3",
+                "symfony/yaml": "~3.0"
+            },
+            "suggest": {
+                "symfony/yaml": "To use the yaml reference dumper"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Config Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-10-04 18:56:58"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v3.3.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "8ebad929aee3ca185b05f55d9cc5521670821ad1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/8ebad929aee3ca185b05f55d9cc5521670821ad1",
+                "reference": "8ebad929aee3ca185b05f55d9cc5521670821ad1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "psr/container": "^1.0"
+            },
+            "conflict": {
+                "symfony/config": "<3.3.1",
+                "symfony/finder": "<3.3",
+                "symfony/yaml": "<3.3"
+            },
+            "provide": {
+                "psr/container-implementation": "1.0"
+            },
+            "require-dev": {
+                "symfony/config": "~3.3",
+                "symfony/expression-language": "~2.8|~3.0",
+                "symfony/yaml": "~3.3"
+            },
+            "suggest": {
+                "symfony/config": "",
+                "symfony/expression-language": "For using expressions in service container configuration",
+                "symfony/finder": "For using double-star glob patterns or when GLOB_BRACE portability is required",
+                "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DependencyInjection Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-10-04 17:15:30"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v3.3.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "d7ba037e4b8221956ab1e221c73c9e27e05dd423"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d7ba037e4b8221956ab1e221c73c9e27e05dd423",
+                "reference": "d7ba037e4b8221956ab1e221c73c9e27e05dd423",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.8|~3.0",
+                "symfony/dependency-injection": "~3.3",
+                "symfony/expression-language": "~2.8|~3.0",
+                "symfony/stopwatch": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-10-02 06:42:24"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v3.3.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "90bc45abf02ae6b7deb43895c1052cb0038506f1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/90bc45abf02ae6b7deb43895c1052cb0038506f1",
+                "reference": "90bc45abf02ae6b7deb43895c1052cb0038506f1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-10-03 13:33:10"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v3.3.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "fdf89e57a723a29baf536e288d6e232c059697b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/fdf89e57a723a29baf536e288d6e232c059697b1",
+                "reference": "fdf89e57a723a29baf536e288d6e232c059697b1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-10-02 06:42:24"
+        },
+        {
+            "name": "ulrichsg/getopt-php",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/getopt-php/getopt-php.git",
+                "reference": "998465c658513f856972dc8e1609cab7c0495425"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/getopt-php/getopt-php/zipball/998465c658513f856972dc8e1609cab7c0495425",
+                "reference": "998465c658513f856972dc8e1609cab7c0495425",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8",
+                "squizlabs/php_codesniffer": "^2.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GetOpt\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ulrich Schmidt-Goertz",
+                    "email": "ulrich@schmidt-goertz.de"
+                },
+                {
+                    "name": "Thomas Flori",
+                    "email": "thflori@gmail.com"
+                }
+            ],
+            "description": "Command line arguments parser for PHP 5.4 - 7.1",
+            "homepage": "http://getopt-php.github.io/getopt-php",
+            "time": "2017-08-24 04:39:24"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3,<8.0-DEV"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2015-06-14 21:17:01"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8e6e04167378abf1ddb4d3522d8755c5fd90d102",
+                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "1.*",
+                "phpunit/phpunit": "~4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "homepage": "https://github.com/myclabs/DeepCopy",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2017-04-12 18:52:22"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2017-09-11 18:02:19"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "3.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/4aada1f93c72c35e22fb1383b47fee43b8f1d157",
+                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/type-resolver": "^0.3.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2017-08-08 06:39:58"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/fb3933512008d8162b3cdf9e18dba9309b7c3773",
+                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2017-06-03 08:32:36"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
+                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
+                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.5|^3.2",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2017-09-04 11:05:03"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-file-iterator": "^1.3",
+                "phpunit/php-text-template": "^1.2",
+                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0",
+                "sebastian/environment": "^1.3.2 || ^2.0",
+                "sebastian/version": "^1.0 || ^2.0"
+            },
+            "require-dev": {
+                "ext-xdebug": "^2.1.4",
+                "phpunit/phpunit": "^5.7"
+            },
+            "suggest": {
+                "ext-xdebug": "^2.5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2017-04-02 07:44:40"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2016-10-03 07:40:28"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21 13:50:34"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "1.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2017-02-26 11:10:40"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "1.4.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2017-02-27 10:12:30"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "5.7.22",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "10df877596c9906d4110b5b905313829043f2ada"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/10df877596c9906d4110b5b905313829043f2ada",
+                "reference": "10df877596c9906d4110b5b905313829043f2ada",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
+                "phpspec/prophecy": "^1.6.2",
+                "phpunit/php-code-coverage": "^4.0.4",
+                "phpunit/php-file-iterator": "~1.4",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": "^1.0.6",
+                "phpunit/phpunit-mock-objects": "^3.2",
+                "sebastian/comparator": "^1.2.4",
+                "sebastian/diff": "^1.4.3",
+                "sebastian/environment": "^1.3.4 || ^2.0",
+                "sebastian/exporter": "~2.0",
+                "sebastian/global-state": "^1.1",
+                "sebastian/object-enumerator": "~2.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "~1.0.3|~2.0",
+                "symfony/yaml": "~2.1|~3.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
+            "suggest": {
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "~1.1"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.7.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2017-09-24 07:23:38"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2 || ^2.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.4"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2017-06-30 09:13:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04 06:30:41"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "1.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.2",
+                "sebastian/exporter": "~1.2 || ~2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2017-01-29 09:50:25"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2017-05-22 07:24:03"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2016-11-26 07:53:53"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/recursion-context": "~2.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2016-11-19 08:54:04"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2015-10-12 03:26:01"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-02-18 15:18:39"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2016-11-19 07:33:16"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28 20:34:47"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2016-10-03 07:35:21"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v3.3.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "8c7bf1e7d5d6b05a690b715729cb4cd0c0a99c46"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/8c7bf1e7d5d6b05a690b715729cb4cd0c0a99c46",
+                "reference": "8c7bf1e7d5d6b05a690b715729cb4cd0c0a99c46",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "require-dev": {
+                "symfony/console": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-10-05 14:43:42"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-11-23 20:04:58"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/config.json
+++ b/config.json
@@ -1,0 +1,5 @@
+{
+	"git.push.remote": "git@gerrit.go2tech.de:extensions/%s.git",
+	"git.update.remote": "https://gerrit.wikimedia.org/r/mediawiki/extensions/%s",
+	"version.prefix": "wmf/"
+}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<ruleset name="MediaWiki">
+    <rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+        <exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationPublic" />
+        <exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationProtected" />
+        <exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationPublic" />
+        <exclude name="MediaWiki.Commenting.FunctionComment.MissingParamTag" />
+        <exclude name="MediaWiki.Commenting.FunctionComment.MissingParamComment" />
+        <exclude name="MediaWiki.Commenting.FunctionComment.MissingParamName" />
+        <exclude name="MediaWiki.Commenting.FunctionComment.MissingReturn" />
+        <exclude name="MediaWiki.Commenting.FunctionComment.ParamNameNoMatch" />
+        <exclude name="MediaWiki.Commenting.FunctionComment.ExtraParamComment" />
+        <exclude name="MediaWiki.Commenting.FunctionComment.WrongStyle" />
+    </rule>
+    <file>.</file>
+    <arg name="encoding" value="UTF-8"/>
+    <arg name="extensions" value="php,php5,inc,sample"/>
+</ruleset>

--- a/src/DroidWiki/Updater.php
+++ b/src/DroidWiki/Updater.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace DroidWiki;
+
+use DroidWiki\Updater\CliOptions;
+use DroidWiki\Updater\Config;
+use GitWrapper\GitWorkingCopy;
+use GitWrapper\GitWrapper;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+
+class Updater implements LoggerAwareInterface {
+	const UPSTREAM_REMOTE_NAME = 'upstream';
+	const COMMIT_MSG_TEMPLATE = 'Update %s to %s
+
+Forward to %s';
+
+	/**
+	 * @var Config
+	 */
+	private $config;
+
+	/**
+	 * @var CliOptions
+	 */
+	private $cliOptions;
+
+	/**
+	 * @var GitWrapper
+	 */
+	private $gitWrapper;
+
+	/**
+	 * @var LoggerInterface
+	 */
+	private $logger;
+
+	/**
+	 * @var bool
+	 */
+	private $needsPush = true;
+
+	/**
+	 * @var string
+	 */
+	private $extensionName;
+
+	/**
+	 * @var string
+	 */
+	private $cwd;
+
+	public function __construct( Config $config, CliOptions $options, GitWrapper $gitWrapper ) {
+		$this->config = $config;
+		$this->cliOptions = $options;
+		$this->gitWrapper = $gitWrapper;
+	}
+
+	public function run() {
+		if ( $this->cliOptions->isListUpdate() ) {
+			$this->getLogger()->debug( 'Got list of extension to update...' );
+			$this->updateList();
+		} else {
+			$this->getLogger()->debug( 'Got one extension to update...' );
+			$this->update( $this->cliOptions->getExtensionName() );
+		}
+	}
+
+	private function updateList() {
+		$list = $this->cliOptions->getList();
+
+		foreach ( $list as $extName ) {
+			$this->update( $extName );
+		}
+	}
+
+	private function update( $extName ) {
+		$this->needsPush = true;
+		$this->extensionName = $extName;
+
+		$this->getLogger()->info( '---Start updating extension {name}...+++',
+			[ 'name' => $extName ] );
+
+		$git = $this->getGitFromExtensionName();
+		$git->checkout( 'master' );
+		$this->fetchUpdateVersion( $git );
+
+		$this->mergeAndCommitChanges( $git );
+
+		if ( $this->needsPush ) {
+			$this->getLogger()->info( 'Pushing changes...' );
+			$git->push();
+		}
+	}
+
+	private function getGitFromExtensionName() {
+		$fsLocation = $this->getCwd() . '/' . $this->extensionName;
+		if ( !is_dir( $fsLocation ) ) {
+			$this->getLogger()->info( 'Extension directory does not exist, cloning...' );
+			return $this->cloneExtension( $fsLocation );
+		}
+
+		$git = $this->gitWrapper->workingCopy( $fsLocation );
+		if ( !$git->isCloned() ) {
+			$this->getLogger()->info( 'Extension isn\'t cloned already, cloning...' );
+			return $this->cloneExtension( $fsLocation );
+		}
+		$this->getLogger()->info( 'Extension is already cloned...' );
+		$this->resetAndPull( $git );
+		$this->addUpdateRemote( $git );
+
+		return $git;
+	}
+
+	private function cloneExtension( $fsLocation ) {
+		if ( !$this->config->has( Config::GIT_PUSH_REMOTE ) ) {
+			throw new \UnexpectedValueException( 'Extension, which should be updated, is '.
+				'not cloned already, but the remote to push to is not configured.' );
+		}
+		$gitWorkingDir = $this->gitWrapper->cloneRepository(
+			sprintf( $this->config->get( Config::GIT_PUSH_REMOTE ), $this->extensionName ),
+			$fsLocation
+		);
+		$this->addUpdateRemote( $gitWorkingDir );
+
+		return $gitWorkingDir;
+	}
+
+	private function resetAndPull( GitWorkingCopy $git ) {
+		if ( $git->hasChanges() ) {
+			$this->getLogger()->info( 'Git clone has changes, resetting...' );
+			$git->reset( [ 'hard' => true ] );
+		}
+		$this->getLogger()->info( 'Checking out master and pull from origin/master...' );
+		$git->checkout( 'master' )->pull( 'origin', 'master' );
+	}
+
+	/**
+	 * Sets a logger instance on the object
+	 *
+	 * @param LoggerInterface $logger
+	 * @return null
+	 */
+	public function setLogger( LoggerInterface $logger ) {
+		$this->logger = $logger;
+	}
+
+	protected function getLogger() {
+		return $this->logger;
+	}
+
+	private function addUpdateRemote( GitWorkingCopy $gitWorkingDir ) {
+		if ( !$this->config->has( Config::GIT_UPDATE_REMOTE ) ) {
+			throw new \UnexpectedValueException( 'Extension, which should be updated, is '.
+				'not cloned already, but the remote to update from is not configured.' );
+		}
+		$gitWorkingDir->getOutput();
+		$remotes = $gitWorkingDir->getRemotes();
+		$expectedRemoteUrl = sprintf(
+			$this->config->get( Config::GIT_UPDATE_REMOTE ),
+			$this->extensionName
+		);
+		if ( $gitWorkingDir->hasRemote( self::UPSTREAM_REMOTE_NAME ) ) {
+			if ( $remotes[self::UPSTREAM_REMOTE_NAME]['fetch'] === $expectedRemoteUrl ) {
+				return;
+			}
+			$gitWorkingDir->removeRemote( self::UPSTREAM_REMOTE_NAME );
+		}
+
+		$this->getLogger()->info(
+			'Update remote does not exist or has wrong URL, adding/updating with URL {url}',
+			[ 'url' => $expectedRemoteUrl ] );
+		$gitWorkingDir->addRemote( self::UPSTREAM_REMOTE_NAME, $expectedRemoteUrl );
+	}
+
+	private function fetchUpdateVersion( GitWorkingCopy $git ) {
+		$versionRefSpec = $this->getVersionRefSpec();
+
+		$this->getLogger()->info( 'Fetching remote ref-spec {refSpec}',
+			[ 'refSpec' => $versionRefSpec ] );
+		$git->fetch( self::UPSTREAM_REMOTE_NAME, $versionRefSpec );
+	}
+
+	private function getVersionRefSpec() {
+		$versionRefSpec = '';
+		if ( $this->config->has( 'version.prefix' ) ) {
+			$versionRefSpec .= $this->config->get( 'version.prefix' );
+		}
+
+		$versionRefSpec .= $this->cliOptions->getVersionNumber();
+
+		return $versionRefSpec;
+	}
+
+	private function mergeAndCommitChanges( GitWorkingCopy $git ) {
+		$refSpec = self::UPSTREAM_REMOTE_NAME . '/' . $this->getVersionRefSpec();
+		$this->getLogger()
+			->info( 'Merging changes from {refSpec} to master with strategy recursive=theirs...',
+				[ 'refSpec' => $refSpec ] );
+		$git->merge( $refSpec, [
+			's' => 'recursive',
+			'X' => 'theirs',
+			'squash' => true,
+		] );
+		if ( !$git->hasChanges() ) {
+			$this->needsPush = false;
+			$this->getLogger()->info( 'Nothing to commit, skipping...' );
+			return;
+		}
+		$this->getLogger()->info( 'Commiting changes...' );
+		$sha1OfRefSpec = $git->getWrapper()->git( 'rev-parse ' . $refSpec, $git->getDirectory() );
+		$git->commit( sprintf(
+			self::COMMIT_MSG_TEMPLATE,
+			$this->extensionName,
+			$this->getVersionRefSpec(),
+			$sha1OfRefSpec
+		) );
+	}
+
+	private function getCwd() {
+		if ( $this->cwd !== null ) {
+			return $this->cwd;
+		}
+		return getcwd();
+	}
+
+	public function setCwd( $cwd ) {
+		$this->cwd = $cwd;
+	}
+}

--- a/src/DroidWiki/Updater/CliOptions.php
+++ b/src/DroidWiki/Updater/CliOptions.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace DroidWiki\Updater;
+
+use Doctrine\Instantiator\Exception\InvalidArgumentException;
+use GetOpt\ArgumentException\Missing;
+use GetOpt\GetOpt;
+use GetOpt\Operand;
+use GetOpt\Option;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+
+class CliOptions implements LoggerAwareInterface {
+	/**
+	 * @var GetOpt
+	 */
+	private $options;
+
+	/**
+	 * @var LoggerInterface
+	 */
+	private $logger;
+
+	public function __construct( GetOpt $options ) {
+		$this->options = $options;
+	}
+
+	public function initOptions( $argvInput = null ) {
+		$this->options->addOptions( [
+			Option::create( 'v', 'version', GetOpt::REQUIRED_ARGUMENT )
+				->setDescription( 'The version number to which this extension should	be updated.' ),
+			Option::create( 'l', 'list', GetOpt::OPTIONAL_ARGUMENT )
+				->setDescription( 'If set, the extension names will be taken from the specified file and all ' .
+					'are updated.' ),
+		] );
+		$this->options->addOperands( [
+			Operand::create( 'extension', Operand::OPTIONAL ),
+		] );
+
+		if ( $argvInput === null ) {
+			$this->options->process();
+		} else {
+			$this->options->process( $argvInput );
+		}
+
+		if ( $this->options->getOption( 'version' ) === null ) {
+			$errorMsg = 'The option --version is required.';
+			$this->getLogger()->error( $errorMsg );
+			$this->getLogger()->info( $this->options->getHelpText() );
+			throw new Missing( $errorMsg );
+		}
+	}
+
+	protected function getLogger() {
+		return $this->logger;
+	}
+
+	/**
+	 * Sets a logger instance on the object
+	 *
+	 * @param LoggerInterface $logger
+	 * @return null
+	 */
+	public function setLogger( LoggerInterface $logger ) {
+		$this->logger = $logger;
+	}
+
+	public function getVersionNumber() {
+		return $this->options->getOption( 'version' );
+	}
+
+	public function getList() {
+		if ( !$this->isListUpdate() ) {
+			throw new NoListUpdateException();
+		}
+
+		$listFile =
+			file( Constants::INSTALL_PATH . $this->options->getOption( 'list' ),
+				FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES );
+		if ( $listFile === false ) {
+			throw new InvalidArgumentException( 'Error during read of ' .
+				$this->options->getOption( 'list' ) );
+		}
+
+		return $listFile;
+	}
+
+	public function isListUpdate() {
+		return $this->options->getOption( 'list' ) !== null;
+	}
+
+	public function getExtensionName() {
+		if ( $this->isListUpdate() ) {
+			throw new NoSingleExtensionUpdateException();
+		}
+
+		return $this->options->getOperand( 0 );
+	}
+}

--- a/src/DroidWiki/Updater/Config.php
+++ b/src/DroidWiki/Updater/Config.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace DroidWiki\Updater;
+
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+class Config {
+	const GIT_UPDATE_REMOTE = 'git.update.remote';
+	const GIT_PUSH_REMOTE = 'git.push.remote';
+	const VERSION_PREFIX = 'version.prefix';
+
+	/**
+	 * @var FileResource
+	 */
+	private $locationFileReference;
+
+	/**
+	 * @var array
+	 */
+	private $jsonConfig;
+
+	public function __construct( $locationOrConfiguration ) {
+		if ( is_array( $locationOrConfiguration ) ) {
+			$this->jsonConfig = $locationOrConfiguration;
+			return;
+		}
+		$this->locationFileReference = new FileResource( $locationOrConfiguration );
+		$this->load();
+	}
+
+	private function load() {
+		$this->jsonConfig = json_decode( file_get_contents( $this->locationFileReference ), true );
+		if ( $this->jsonConfig === null ) {
+			throw new InvalidArgumentException(
+				sprintf( 'The file "%s" is empty or not valid json.',
+					$this->locationFileReference->getResource() )
+			);
+		}
+	}
+
+	/**
+	 * @param $key
+	 * @return bool
+	 */
+	public function has( $key ) {
+		return isset( $this->jsonConfig[ $key ] );
+	}
+
+	public function get( $key, $default = null ) {
+		if ( $this->has( $key ) ) {
+			return $this->jsonConfig[ $key ];
+		}
+		if ( func_num_args() === 1 ) {
+			throw new ConfigNotFoundException( sprintf( 'The configuration "%s" does not exist.',
+				$key ) );
+		}
+		return $default;
+	}
+}

--- a/src/DroidWiki/Updater/ConfigNotFoundException.php
+++ b/src/DroidWiki/Updater/ConfigNotFoundException.php
@@ -1,0 +1,5 @@
+<?php
+namespace DroidWiki\Updater;
+
+class ConfigNotFoundException extends \Exception {
+}

--- a/src/DroidWiki/Updater/Constants.php
+++ b/src/DroidWiki/Updater/Constants.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace DroidWiki\Updater;
+
+/**
+ * This class is not meant to be instantiated in any way and simply holds constants of
+ * values that needs to be available before the Config object is initialized.
+ */
+final class Constants {
+	const INSTALL_PATH = __DIR__ . '/../../../';
+	const CONFIG_PATH = self::INSTALL_PATH . 'config.json';
+
+	private function __construct() {
+		throw new \Exception();
+	}
+}

--- a/src/DroidWiki/Updater/NoListUpdateException.php
+++ b/src/DroidWiki/Updater/NoListUpdateException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace DroidWiki\Updater;
+
+class NoListUpdateException extends \Exception {
+}

--- a/src/DroidWiki/Updater/NoSingleExtensionUpdateException.php
+++ b/src/DroidWiki/Updater/NoSingleExtensionUpdateException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace DroidWiki\Updater;
+
+class NoSingleExtensionUpdateException extends \Exception {
+}

--- a/src/RuntimeStart.php
+++ b/src/RuntimeStart.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * A file wrapping the startup of the updater script, which src to
+ * require necessary files, like the composer autoloader, and default configuration
+ * options.
+ */
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+
+require dirname( __DIR__ ) . '/vendor/autoload.php';
+
+$container = new ContainerBuilder();
+$loader = new XmlFileLoader( $container, new FileLocator( __DIR__ ) );
+$loader->load( 'services.xml' );

--- a/src/services.xml
+++ b/src/services.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="config.location" type="constant">DroidWiki\Updater\Constants::CONFIG_PATH</parameter>
+    </parameters>
+
+    <services>
+        <service id="config" class="DroidWiki\Updater\Config">
+            <argument>%config.location%</argument>
+        </service>
+        <service id="updater" class="DroidWiki\Updater">
+            <argument type="service" id="config" />
+            <argument type="service" id="clioptions" />
+            <argument type="service" id="git-wrapper" />
+            <call method="setLogger">
+                <argument type="service" id="logger" />
+            </call>
+        </service>
+        <service id="clioptions" class="DroidWiki\Updater\CliOptions">
+            <argument type="service" id="getopt-php" />
+            <call method="setLogger">
+                <argument type="service" id="logger" />
+            </call>
+            <call method="initOptions" />
+        </service>
+
+
+        <service id="getopt-php" class="GetOpt\GetOpt" />
+        <service id="git-wrapper" class="GitWrapper\GitWrapper" />
+        <service id="logger" class="GAubry\Logger\ColoredIndentedLogger" />
+    </services>
+</container>

--- a/tests/DroidWiki/TestExisting/README
+++ b/tests/DroidWiki/TestExisting/README
@@ -1,0 +1,1 @@
+This directory is just added for testing to have is_dir() returning true.

--- a/tests/DroidWiki/Updater/CliOptionsTest.php
+++ b/tests/DroidWiki/Updater/CliOptionsTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace DroidWiki\Updater;
+
+use GetOpt\ArgumentException\Missing;
+use GetOpt\ArgumentException\Unexpected;
+use GetOpt\GetOpt;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class CliOptionsTest extends TestCase {
+	private $testOptions = [
+		'-v',
+		'10',
+	];
+
+	private $expectedExtensionList = [
+		'TestExtension1',
+		'TestExtension2',
+	];
+
+	/**
+	 * @var CliOptions
+	 */
+	private $initializedCliOptions;
+
+	private $logger;
+
+	public function setUp() {
+		$this->logger = $this->createMock( LoggerInterface::class );
+		$this->initializedCliOptions = new CliOptions( new GetOpt() );
+		$this->initializedCliOptions->initOptions( $this->testOptions );
+		$this->initializedCliOptions->setLogger( $this->logger );
+	}
+
+	public function testShortGetVersionNumber() {
+		$this->assertEquals( '10', $this->initializedCliOptions->getVersionNumber() );
+	}
+
+	public function testVersionISrequired() {
+		$this->expectException( Missing::class );
+		$cliOptions = new CliOptions( new GetOpt() );
+		$cliOptions->setLogger( $this->logger );
+		$cliOptions->initOptions( [] );
+	}
+
+	public function testLongGetVersionNumber() {
+		$cliOptions = new CliOptions( new GetOpt() );
+		$cliOptions->initOptions( [
+			'--version',
+			'10',
+		] );
+		$cliOptions->setLogger( $this->logger );
+		$this->assertEquals( '10', $cliOptions->getVersionNumber() );
+	}
+
+	public function testUnknownArgument() {
+		$this->expectException( Unexpected::class );
+		$cliOptions = new CliOptions( new GetOpt() );
+		$cliOptions->setLogger( $this->logger );
+		$cliOptions->initOptions( [
+			'--unknown',
+		] );
+	}
+
+	public function testIsListUpdateWithOutArgument() {
+		$this->assertFalse( $this->initializedCliOptions->isListUpdate() );
+	}
+
+	public function testIsListUpdateShort() {
+		$cliOptions = new CliOptions( new GetOpt() );
+		$cliOptions->setLogger( $this->logger );
+		$cliOptions->initOptions( [
+			'-l',
+			'extensions.list',
+			'-v',
+			'10',
+		] );
+		$this->assertTrue( $cliOptions->isListUpdate() );
+	}
+
+	public function testIsListUpdateLong() {
+		$cliOptions = new CliOptions( new GetOpt() );
+		$cliOptions->setLogger( $this->logger );
+		$cliOptions->initOptions( [
+			'--list',
+			'extensions.list',
+			'-v',
+			'10',
+		] );
+		$this->assertTrue( $cliOptions->isListUpdate() );
+	}
+
+	public function testGetListExceptionIsListUpdateFalse() {
+		$this->expectException( NoListUpdateException::class );
+		$cliOptions = new CliOptions( new GetOpt() );
+		$cliOptions->setLogger( $this->logger );
+		$this->assertFalse( $cliOptions->isListUpdate() );
+		$cliOptions->getList();
+	}
+
+	public function testGetListShort() {
+		$cliOptions = new CliOptions( new GetOpt() );
+		$cliOptions->setLogger( $this->logger );
+		$cliOptions->initOptions( [
+			'-l',
+			'tests/extensions.list',
+			'-v',
+			'10',
+		] );
+		$this->assertEquals( $this->expectedExtensionList, $cliOptions->getList() );
+	}
+
+	public function testGetListLong() {
+		$cliOptions = new CliOptions( new GetOpt() );
+		$cliOptions->setLogger( $this->logger );
+		$cliOptions->initOptions( [
+			'--list',
+			'tests/extensions.list',
+			'-v',
+			'10',
+		] );
+		$this->assertEquals( $this->expectedExtensionList, $cliOptions->getList() );
+	}
+
+	public function testGetExtensionNameIsListUpdateTrue() {
+		$this->expectException( NoSingleExtensionUpdateException::class );
+		$cliOptions = new CliOptions( new GetOpt() );
+		$cliOptions->setLogger( $this->logger );
+		$cliOptions->initOptions( [
+			'-l',
+			'tests/extensions.list',
+			'-v',
+			'10',
+		] );
+		$this->assertTrue( $cliOptions->isListUpdate() );
+		$cliOptions->getExtensionName();
+	}
+
+	public function testGetExtensionNameIsListUpdateFalse() {
+		$cliOptions = new CliOptions( new GetOpt() );
+		$cliOptions->setLogger( $this->logger );
+		$this->assertFalse( $cliOptions->isListUpdate() );
+		$cliOptions->getExtensionName();
+	}
+
+	public function testGetExtensionName() {
+		$cliOptions = new CliOptions( new GetOpt() );
+		$cliOptions->setLogger( $this->logger );
+		$cliOptions->initOptions( [
+			'TestExtension',
+			'-v',
+			'10',
+		] );
+		$this->assertEquals( 'TestExtension', $cliOptions->getExtensionName() );
+	}
+}

--- a/tests/DroidWiki/Updater/ConfigTest.php
+++ b/tests/DroidWiki/Updater/ConfigTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace DroidWiki\Updater;
+
+use PHPUnit\Framework\TestCase;
+
+class ConfigTest extends TestCase {
+	private $testConfig = [
+		'test' => true,
+	];
+
+	/**
+	 * @var Config
+	 */
+	private $initializedConfig;
+
+	public function setUp() {
+		$this->initializedConfig = new Config( $this->testConfig );
+	}
+
+	public function testArrayConstructor() {
+		$config = new Config( $this->testConfig );
+		$this->assertTrue( $config->has( 'test' ),
+			'Initializing a Config object with an array should contain the config options of that array.' );
+	}
+
+	public function testHasNonExisting() {
+		$this->assertFalse( $this->initializedConfig->has( 'test2' ),
+			'#has() should return false for non-existing configurations.' );
+	}
+
+	public function testHasExisting() {
+		$this->assertFalse( $this->initializedConfig->has( 'test2' ),
+			'#has() should return false for non-existing configurations.' );
+	}
+
+	public function testGetExisting() {
+		$this->assertTrue( $this->initializedConfig->get( 'test' ),
+			'Requesting an existing config option should return it\'s value.' );
+	}
+
+	public function testGetNonExisting() {
+		$this->expectException( ConfigNotFoundException::class );
+		$this->initializedConfig->get( 'nonExisting' );
+	}
+
+	public function testGetNonExistingWithDefault() {
+		$this->assertEquals( 'defaultValue', $this->initializedConfig->get( 'nonExisting',
+			'defaultValue' ),
+			'Requesting a non-existing config value with a default value should return ' .
+			'the default value.' );
+	}
+
+	public function testGetExistingWithDefault() {
+		$this->assertTrue( $this->initializedConfig->get( 'test', 'defaultValue' ),
+			'Requesting an existing config value with a default value should return ' .
+			'the config value.' );
+	}
+}

--- a/tests/DroidWiki/UpdaterTest.php
+++ b/tests/DroidWiki/UpdaterTest.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace DroidWiki;
+
+use DroidWiki\Updater\CliOptions;
+use DroidWiki\Updater\Config;
+use GitWrapper\GitWorkingCopy;
+use GitWrapper\GitWrapper;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class UpdaterTest extends TestCase {
+
+	private $logger;
+	private $config;
+
+	public function setUp() {
+		$this->logger = $this->createMock( LoggerInterface::class );
+		$this->config = $this->createMock( Config::class );
+		$this->config->method( 'has' )->withAnyParameters()->willReturn( true );
+		$this->config->method( 'get' )
+			->withAnyParameters()
+			->willReturn( 'testValue/' );
+	}
+
+	public function testRunNonExistingClones() {
+		$cliOptions = $this->createMock( CliOptions::class );
+		$cliOptions->method( 'isListUpdate' )->willReturn( false );
+		$cliOptions->method( 'getExtensionName' )->willReturn( 'TestNonExisting' );
+
+		$gitWrapper = $this->createMock( GitWrapper::class );
+		$workingCopy = $this->createMock( GitWorkingCopy::class );
+		$gitWrapper->method( 'cloneRepository' )->willReturn( $workingCopy );
+		$gitWrapper->expects( $this->once() )->method( 'cloneRepository' );
+
+		$updater = new Updater( $this->config, $cliOptions, $gitWrapper );
+		$updater->setLogger( $this->logger );
+		$updater->run();
+	}
+
+	public function testRunExistingDoesNotClone() {
+		$cliOptions = $this->createMock( CliOptions::class );
+		$cliOptions->method( 'isListUpdate' )->willReturn( false );
+		$cliOptions->method( 'getExtensionName' )->willReturn( 'TestExisting' );
+
+		$gitWrapper = $this->createMock( GitWrapper::class );
+		$workingCopy = $this->createMock( GitWorkingCopy::class );
+		$workingCopy->method( 'isCloned' )->willReturn( true );
+		$gitWrapper->method( 'cloneRepository' )->willReturn( $workingCopy );
+		$workingCopy->method( 'checkout' )->willReturn( $workingCopy );
+		$gitWrapper->method( 'workingCopy' )->willReturn( $workingCopy );
+		$gitWrapper->expects( $this->never() )->method( 'cloneRepository' );
+
+		$updater = new Updater( $this->config, $cliOptions, $gitWrapper );
+		$updater->setLogger( $this->logger );
+		$updater->setCwd( __DIR__ );
+		$updater->run();
+	}
+
+	public function testRunResetWhenChanges() {
+		$cliOptions = $this->createMock( CliOptions::class );
+		$cliOptions->method( 'isListUpdate' )->willReturn( false );
+		$cliOptions->method( 'getExtensionName' )->willReturn( 'TestExisting' );
+
+		$gitWrapper = $this->createMock( GitWrapper::class );
+		$workingCopy = $this->createMock( GitWorkingCopy::class );
+		$workingCopy->method( 'isCloned' )->willReturn( true );
+		$gitWrapper->method( 'cloneRepository' )->willReturn( $workingCopy );
+		$workingCopy->method( 'checkout' )->willReturn( $workingCopy );
+		$workingCopy->method( 'hasChanges' )->willReturn( true );
+		$workingCopy->method( 'reset' )->willReturn( true );
+		$workingCopy->method( 'getWrapper' )->willReturn( $gitWrapper );
+		$gitWrapper->method( 'workingCopy' )->willReturn( $workingCopy );
+
+		$workingCopy->expects( $this->once() )->method( 'reset' );
+
+		$updater = new Updater( $this->config, $cliOptions, $gitWrapper );
+		$updater->setLogger( $this->logger );
+		$updater->setCwd( __DIR__ );
+		$updater->run();
+	}
+
+	public function testRunAddsRemote() {
+		$cliOptions = $this->createMock( CliOptions::class );
+		$cliOptions->method( 'isListUpdate' )->willReturn( false );
+		$cliOptions->method( 'getExtensionName' )->willReturn( 'TestExisting' );
+
+		$gitWrapper = $this->createMock( GitWrapper::class );
+		$workingCopy = $this->createMock( GitWorkingCopy::class );
+		$workingCopy->method( 'isCloned' )->willReturn( true );
+		$gitWrapper->method( 'cloneRepository' )->willReturn( $workingCopy );
+		$workingCopy->method( 'checkout' )->willReturn( $workingCopy );
+		$gitWrapper->method( 'workingCopy' )->willReturn( $workingCopy );
+
+		$workingCopy->expects( $this->once() )->method( 'addRemote' );
+
+		$updater = new Updater( $this->config, $cliOptions, $gitWrapper );
+		$updater->setLogger( $this->logger );
+		$updater->run();
+	}
+
+	public function testRunUpdatesRemote() {
+		$cliOptions = $this->createMock( CliOptions::class );
+		$cliOptions->method( 'isListUpdate' )->willReturn( false );
+		$cliOptions->method( 'getExtensionName' )->willReturn( 'TestExisting' );
+
+		$gitWrapper = $this->createMock( GitWrapper::class );
+		$workingCopy = $this->createMock( GitWorkingCopy::class );
+		$workingCopy->method( 'isCloned' )->willReturn( true );
+		$gitWrapper->method( 'cloneRepository' )->willReturn( $workingCopy );
+		$workingCopy->method( 'checkout' )->willReturn( $workingCopy );
+		$workingCopy->method( 'hasRemote' )->willReturn( true );
+		$workingCopy->method( 'getRemotes' )->willReturn( [
+			Updater::UPSTREAM_REMOTE_NAME => [
+				'fetch' => 'test'
+			]
+		] );
+		$gitWrapper->method( 'workingCopy' )->willReturn( $workingCopy );
+
+		$workingCopy->expects( $this->once() )->method( 'removeRemote' );
+		$workingCopy->expects( $this->once() )->method( 'addRemote' );
+
+		$updater = new Updater( $this->config, $cliOptions, $gitWrapper );
+		$updater->setLogger( $this->logger );
+		$updater->run();
+	}
+
+	public function testRunNoAddRemoveRemote() {
+		$cliOptions = $this->createMock( CliOptions::class );
+		$cliOptions->method( 'isListUpdate' )->willReturn( false );
+		$cliOptions->method( 'getExtensionName' )->willReturn( 'TestExisting' );
+
+		$gitWrapper = $this->createMock( GitWrapper::class );
+		$workingCopy = $this->createMock( GitWorkingCopy::class );
+		$workingCopy->method( 'isCloned' )->willReturn( true );
+		$gitWrapper->method( 'cloneRepository' )->willReturn( $workingCopy );
+		$workingCopy->method( 'checkout' )->willReturn( $workingCopy );
+		$workingCopy->method( 'hasRemote' )->willReturn( true );
+		$workingCopy->method( 'getRemotes' )->willReturn( [
+			Updater::UPSTREAM_REMOTE_NAME => [
+				'fetch' => 'testValue/'
+			]
+		] );
+		$gitWrapper->method( 'workingCopy' )->willReturn( $workingCopy );
+
+		$workingCopy->expects( $this->never() )->method( 'removeRemote' );
+		$workingCopy->expects( $this->never() )->method( 'addRemote' );
+
+		$updater = new Updater( $this->config, $cliOptions, $gitWrapper );
+		$updater->setLogger( $this->logger );
+		$updater->run();
+	}
+
+	public function testRunTestSingle() {
+		$cliOptions = $this->createMock( CliOptions::class );
+		$cliOptions->method( 'isListUpdate' )->willReturn( false );
+		$cliOptions->method( 'getExtensionName' )->willReturn( 'TestExisting' );
+		$cliOptions->method( 'getVersionNumber' )->willReturn( '1.3.0-wmf.1' );
+
+		$gitWrapper = $this->createMock( GitWrapper::class );
+		$workingCopy = $this->createMock( GitWorkingCopy::class );
+		$workingCopy->method( 'isCloned' )->willReturn( true );
+		$gitWrapper->method( 'cloneRepository' )->willReturn( $workingCopy );
+		$workingCopy->method( 'checkout' )->willReturn( $workingCopy );
+		$workingCopy->method( 'getWrapper' )->willReturn( $gitWrapper );
+		$workingCopy->method( 'hasChanges' )->willReturn( true );
+		$gitWrapper->method( 'workingCopy' )->willReturn( $workingCopy );
+
+		$workingCopy->expects( $this->once() )->method( 'pull' );
+		$workingCopy->expects( $this->exactly( 2 ) )->method( 'checkout' )->with( 'master' );
+		$workingCopy->expects( $this->once() )->method( 'commit' );
+		$workingCopy->expects( $this->once() )->method( 'merge' )->with(
+			'upstream/testValue/1.3.0-wmf.1',
+			[
+				's' => 'recursive',
+				'X' => 'theirs',
+				'squash' => true,
+			]
+		);
+		$workingCopy->expects( $this->once() )->method( 'fetch' )->with(
+			'upstream', 'testValue/1.3.0-wmf.1' );
+
+		$updater = new Updater( $this->config, $cliOptions, $gitWrapper );
+		$updater->setLogger( $this->logger );
+		$updater->setCwd( __DIR__ );
+		$updater->run();
+	}
+
+	public function testRunNoChangesNoCommit() {
+		$cliOptions = $this->createMock( CliOptions::class );
+		$cliOptions->method( 'isListUpdate' )->willReturn( false );
+		$cliOptions->method( 'getExtensionName' )->willReturn( 'TestExisting' );
+		$cliOptions->method( 'getVersionNumber' )->willReturn( '1.3.0-wmf.1' );
+
+		$gitWrapper = $this->createMock( GitWrapper::class );
+		$workingCopy = $this->createMock( GitWorkingCopy::class );
+		$workingCopy->method( 'isCloned' )->willReturn( true );
+		$gitWrapper->method( 'cloneRepository' )->willReturn( $workingCopy );
+		$workingCopy->method( 'checkout' )->willReturn( $workingCopy );
+		$workingCopy->method( 'getWrapper' )->willReturn( $gitWrapper );
+		$workingCopy->method( 'hasChanges' )->willReturn( false );
+		$gitWrapper->method( 'workingCopy' )->willReturn( $workingCopy );
+
+		$workingCopy->expects( $this->once() )->method( 'pull' );
+		$workingCopy->expects( $this->exactly( 2 ) )->method( 'checkout' )->with( 'master' );
+		$workingCopy->expects( $this->never() )->method( 'commit' );
+		$workingCopy->expects( $this->once() )->method( 'merge' )->with(
+			'upstream/testValue/1.3.0-wmf.1',
+			[
+				's' => 'recursive',
+				'X' => 'theirs',
+				'squash' => true,
+			]
+		);
+		$workingCopy->expects( $this->once() )->method( 'fetch' )->with(
+			'upstream', 'testValue/1.3.0-wmf.1' );
+
+		$updater = new Updater( $this->config, $cliOptions, $gitWrapper );
+		$updater->setLogger( $this->logger );
+		$updater->setCwd( __DIR__ );
+		$updater->run();
+	}
+}

--- a/tests/extensions.list
+++ b/tests/extensions.list
@@ -1,0 +1,2 @@
+TestExtension1
+TestExtension2

--- a/update.php
+++ b/update.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * Main entry point for the updater script. The script may take
+ * the following parameters:
+ * ...
+ */
+require_once __DIR__ . '/src/RuntimeStart.php';
+
+$container->get( 'updater' )->run();


### PR DESCRIPTION
This should be easier to maintain as a shell script whith different
vriables and stupid mv and rm tasks. The php script handles updates
in a more reasonable way with git merge. Let's see, if that works
as expected for the next deployment.